### PR TITLE
fixes for missing isbn

### DIFF
--- a/safaribooks.py
+++ b/safaribooks.py
@@ -863,7 +863,7 @@ class SafariBooks:
                              for sub in self.book_info["subjects"])
 
         return self.CONTENT_OPF.format(
-            (self.book_info["isbn"] if (isinstance(self.book_info["isbn"], str) and len(self.book_info["isbn"])) else self.book_id),
+            (self.book_info["isbn"] if self.book_info["isbn"] else self.book_id),
             escape(self.book_title),
             authors,
             escape(self.book_info["description"]),
@@ -918,7 +918,7 @@ class SafariBooks:
 
         navmap, _, max_depth = self.parse_toc(response)
         return self.TOC_NCX.format(
-            (self.book_info["isbn"] if (isinstance(self.book_info["isbn"], str) and len(self.book_info["isbn"])) else self.book_id),
+            (self.book_info["isbn"] if self.book_info["isbn"] else self.book_id),
             max_depth,
             self.book_title,
             ", ".join(aut["name"] for aut in self.book_info["authors"]),

--- a/safaribooks.py
+++ b/safaribooks.py
@@ -863,7 +863,7 @@ class SafariBooks:
                              for sub in self.book_info["subjects"])
 
         return self.CONTENT_OPF.format(
-            (self.book_info["isbn"] if len(self.book_info["isbn"]) else self.book_id),
+            (self.book_info["isbn"] if (isinstance(self.book_info["isbn"], str) and len(self.book_info["isbn"])) else self.book_id),
             escape(self.book_title),
             authors,
             escape(self.book_info["description"]),
@@ -918,7 +918,7 @@ class SafariBooks:
 
         navmap, _, max_depth = self.parse_toc(response)
         return self.TOC_NCX.format(
-            (self.book_info["isbn"] if len(self.book_info["isbn"]) else self.book_id),
+            (self.book_info["isbn"] if (isinstance(self.book_info["isbn"], str) and len(self.book_info["isbn"])) else self.book_id),
             max_depth,
             self.book_title,
             ", ".join(aut["name"] for aut in self.book_info["authors"]),


### PR DESCRIPTION
I had this issue with book id `9781617290763`
```
[-] Title: Neo4j in Action
[-] Authors: Aleksa Vukotic and Nicki Watt with Tareq Abedrabbo, Dominic Fox, and Jonas Partner
[-] Identifier: 9781617290763
[-] ISBN: None
```

Logs:
```
[08/Mar/2018 19:31:31] Downloading book images... (233 files)
[08/Mar/2018 19:35:59] Creating EPUB file...
[08/Mar/2018 19:35:59]   File "safaribooks.py", line 1002, in <module>
    SafariBooks(args_parsed)
  File "safaribooks.py", line 347, in __init__
    self.create_epub()
  File "safaribooks.py", line 941, in create_epub
    self.create_content_opf().encode("utf-8", "xmlcharrefreplace")
  File "safaribooks.py", line 866, in create_content_opf
    (self.book_info["isbn"] if len(self.book_info["isbn"]) else self.book_id),

[08/Mar/2018 19:35:59] Unhandled Exception: object of type 'NoneType' has no len() (type: TypeError)
[08/Mar/2018 19:35:59] Last request done:
	URL: https://www.safaribooksonline.com/library/view/neo4j-in-action/9781617290763/268fig04.jpg
```