### PR TITLE
Handle mailto: links and empty/nonexistent copyright

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ Books/
 
 cookies.json
 *.log
+.idea

--- a/safaribooks.py
+++ b/safaribooks.py
@@ -555,7 +555,7 @@ class SafariBooks:
                 if "cover" in link or "images" in link or "graphics" in link or \
                         link[-3:] in ["jpg", "peg", "png", "gif"]:
                     link = urljoin(self.base_url, link)
-                    if link not in self.images:
+                    if link not in self.images and not link.startswith('mailto:'):
                         self.images.append(link)
                         self.display.log("Crawler: found a new image at %s" % link)
 
@@ -806,10 +806,9 @@ class SafariBooks:
                                               stream=True)
             if response == 0:
                 self.display.error("Error trying to retrieve this image: %s\n    From: %s" % (image_name, url))
-            else:
-              with open(image_path, 'wb') as img:
-                  for chunk in response.iter_content(1024):
-                      img.write(chunk)
+            with open(image_path, 'wb') as img:
+                for chunk in response.iter_content(1024):
+                    img.write(chunk)
 
         self.images_done_queue.put(1)
         self.display.state(len(self.images), self.images_done_queue.qsize())

--- a/safaribooks.py
+++ b/safaribooks.py
@@ -806,10 +806,10 @@ class SafariBooks:
                                               stream=True)
             if response == 0:
                 self.display.error("Error trying to retrieve this image: %s\n    From: %s" % (image_name, url))
-
-            with open(image_path, 'wb') as img:
-                for chunk in response.iter_content(1024):
-                    img.write(chunk)
+            else:
+              with open(image_path, 'wb') as img:
+                  for chunk in response.iter_content(1024):
+                      img.write(chunk)
 
         self.images_done_queue.put(1)
         self.display.state(len(self.images), self.images_done_queue.qsize())
@@ -894,7 +894,7 @@ class SafariBooks:
             escape(self.book_info["description"]),
             subjects,
             ", ".join(escape(pub["name"]) for pub in self.book_info["publishers"]),
-            escape(self.book_info["rights"]),
+            escape(self.book_info["rights"]) if self.book_info["rights"] else "",
             self.book_info["issued"],
             self.cover,
             "\n".join(manifest),

--- a/safaribooks.py
+++ b/safaribooks.py
@@ -552,10 +552,11 @@ class SafariBooks:
     def link_replace(self, link):
         if link:
             if not self.url_is_absolute(link):
-                if "cover" in link or "images" in link or "graphics" in link or \
-                        link[-3:] in ["jpg", "peg", "png", "gif"]:
+                if ("cover" in link or "images" in link or "graphics" in link or \
+                        link[-3:] in ["jpg", "peg", "png", "gif"]) \
+                        and not link.startswith("mailto:"):
                     link = urljoin(self.base_url, link)
-                    if link not in self.images and not link.startswith('mailto:'):
+                    if link not in self.images:
                         self.images.append(link)
                         self.display.log("Crawler: found a new image at %s" % link)
 


### PR DESCRIPTION
Gracefully handle errors due to missing copyrights and/or image paths.