### PR TITLE
add ':' to escape_dirname

### DIFF
--- a/safaribooks.py
+++ b/safaribooks.py
@@ -693,7 +693,7 @@ class SafariBooks:
             elif "win" in sys.platform:
                 dirname = dirname.replace(":", ",")
 
-        for ch in ['~', '#', '%', '&', '*', '{', '}', '\\', '<', '>', '?', '/', '`', '\'', '"', '|', '+']:
+        for ch in ['~', '#', '%', '&', '*', '{', '}', '\\', '<', '>', '?', '/', '`', '\'', '"', '|', '+', ':']:
             if ch in dirname:
                 dirname = dirname.replace(ch, "_")
 


### PR DESCRIPTION
colon ':' is not valid for file name.