### PR TITLE
Avoid retrieving truncated book chapters/pages/sections

### DIFF
--- a/safaribooks.py
+++ b/safaribooks.py
@@ -386,9 +386,10 @@ class SafariBooks:
 
     def update_cookies(self, jar):
         for cookie in jar:
-            self.cookies.update({
-                cookie.name: cookie.value
-            })
+            if cookie.name != 'sessionid':
+                self.cookies.update({
+                    cookie.name: cookie.value
+                })
 
     def requests_provider(
             self, url, post=False, data=None, perfom_redirect=True, update_cookies=True, update_referer=True, **kwargs


### PR DESCRIPTION
When modifying the 'sessionid' after each call to oreilly api,
there are calls that are considered not-authenticated and we retrieved
truncated chapters/pages.
By avoiding adding/modifying it, all the calls are correctly authenticated
and we manage to retrieve full chapters/pages.

This relates to #103 and #129 