### PR TITLE
Fix TypeError when printing color codes to stdout

### DIFF
--- a/safaribooks.py
+++ b/safaribooks.py
@@ -70,7 +70,13 @@ class Display:
         self.logger.info(str(message))  # TODO: "utf-8", "replace"
 
     def out(self, put):
-        sys.stdout.write("\r" + " " * self.columns + "\r" + str(put, "utf-8", "replace") + "\n")
+        pattern = "\r{!s}\r{!s}\n"
+        try:
+            s = pattern.format(
+                " " * self.columns, str(put, "utf-8", "replace"))
+        except TypeError:
+            s = pattern.format(" " * self.columns, put)
+        sys.stdout.write(s)
 
     def info(self, message, state=False):
         self.log(message)
@@ -417,7 +423,7 @@ class SafariBooks:
 
         if update_referer:
             # TODO Update Referer HTTP Header
-            # TODO How about Origin? 
+            # TODO How about Origin?
             self.HEADERS["referer"] = response.request.url
 
         if response.is_redirect and perfom_redirect:


### PR DESCRIPTION
`TypeError` exception is thrown when `str()` function treats terminal color code (e.g. `\033[33m`) as UTF-8:

```python
In [2]: str("\033[33m", "utf-8", "replace")
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-2-54259ae346a9> in <module>()
----> 1 str("\033[33m", "utf-8", "replace")

TypeError: decoding str is not supported
```

Resolves #125 #139 #115 #101 