### PR TITLE
Handle orm-rt cookie issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .vscode/
 .venv/
 .env/
+venv
 
 Books/
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 lxml>=4.1.1
-requests>=2.20.0
+requests>=2.22.0
 

--- a/safaribooks.py
+++ b/safaribooks.py
@@ -9,6 +9,7 @@ import logging
 import argparse
 import requests
 import traceback
+import re
 from lxml import html, etree
 from html import escape
 from random import random
@@ -406,12 +407,14 @@ class SafariBooks:
 
         return self.HEADERS
 
-    def update_cookies(self, jar):
+    def update_cookies(self, jar, set_cookie_header):
         for cookie in jar:
-            if cookie.name != 'sessionid':  # TODO
-                self.cookies.update({
-                    cookie.name: cookie.value
-                })
+            self.cookies.update({
+                cookie.name: cookie.value
+            })
+        orm_rt_cookie_search_result = re.search(r'orm-rt=(\S*)', set_cookie_header)
+        if orm_rt_cookie_search_result:
+            self.cookies["orm-rt"] = orm_rt_cookie_search_result.group(1)
 
     def requests_provider(
             self, url, post=False, data=None, perfom_redirect=True, update_cookies=True, update_referer=True, **kwargs
@@ -436,7 +439,7 @@ class SafariBooks:
             return 0
 
         if update_cookies:
-            self.update_cookies(response.cookies)
+            self.update_cookies(response.cookies, response.headers.get("Set-Cookie", ""))
 
         if update_referer:
             # TODO Update Referer HTTP Header

--- a/safaribooks.py
+++ b/safaribooks.py
@@ -394,7 +394,7 @@ class SafariBooks:
                 for name, parsed_morsel in SimpleCookie(morsel_without_float_max_age).items():
                     self.session.cookies.set(name, parsed_morsel)
 
-    def requests_provider(self, url, post=False, data=None, perfom_redirect=True, **kwargs):
+    def requests_provider(self, url, post=False, data=None, perform_redirect=True, **kwargs):
         try:
             response = getattr(self.session, "post" if post else "get")(url, data=data, allow_redirects=False, **kwargs)
             self.update_cookie_jar_with_float_max_age_cookies(response.raw.headers.getlist("Set-Cookie"))
@@ -409,8 +409,8 @@ class SafariBooks:
             self.display.error(str(request_exception))
             return 0
 
-        if response.is_redirect and perfom_redirect:
-            return self.requests_provider(response.next.url, post, None, perfom_redirect)
+        if response.is_redirect and perform_redirect:
+            return self.requests_provider(response.next.url, post, None, perform_redirect)
             # TODO How about **kwargs?
 
         return response
@@ -445,7 +445,7 @@ class SafariBooks:
                 "password": password,
                 "redirect_uri": redirect_uri
             },
-            perfom_redirect=False
+            perform_redirect=False
         )
 
         if response == 0:
@@ -476,7 +476,7 @@ class SafariBooks:
 
 
     def check_login(self):
-        response = self.requests_provider(PROFILE_URL, perfom_redirect=False)
+        response = self.requests_provider(PROFILE_URL, perform_redirect=False)
 
         if response == 0:
             self.display.exit("Login: unable to reach Safari Books Online. Try again...")

--- a/safaribooks.py
+++ b/safaribooks.py
@@ -394,9 +394,14 @@ class SafariBooks:
                 for name, parsed_morsel in SimpleCookie(morsel_without_float_max_age).items():
                     self.session.cookies.set(name, parsed_morsel)
 
-    def requests_provider(self, url, post=False, data=None, perform_redirect=True, **kwargs):
+    def requests_provider(self, url, is_post=False, data=None, perform_redirect=True, **kwargs):
         try:
-            response = getattr(self.session, "post" if post else "get")(url, data=data, allow_redirects=False, **kwargs)
+            response = getattr(self.session, "post" if is_post else "get")(
+                url,
+                data=data,
+                allow_redirects=False,
+                **kwargs
+            )
             self.update_cookie_jar_with_float_max_age_cookies(response.raw.headers.getlist("Set-Cookie"))
 
             self.display.last_request = (
@@ -410,7 +415,7 @@ class SafariBooks:
             return 0
 
         if response.is_redirect and perform_redirect:
-            return self.requests_provider(response.next.url, post, None, perform_redirect)
+            return self.requests_provider(response.next.url, is_post, None, perform_redirect)
             # TODO How about **kwargs?
 
         return response
@@ -439,7 +444,7 @@ class SafariBooks:
 
         response = self.requests_provider(
             self.LOGIN_URL,
-            post=True,
+            is_post=True,
             json={
                 "email": email,
                 "password": password,

--- a/safaribooks.py
+++ b/safaribooks.py
@@ -28,6 +28,7 @@ API_ORIGIN_HOST = "api." + ORLY_BASE_HOST
 ORLY_BASE_URL = "https://www." + ORLY_BASE_HOST
 SAFARI_BASE_URL = "https://" + SAFARI_BASE_HOST
 API_ORIGIN_URL = "https://" + API_ORIGIN_HOST
+PROFILE_URL = SAFARI_BASE_URL + "/profile/"
 
 
 class Display:
@@ -321,6 +322,8 @@ class SafariBooks:
             if not args.no_cookies:
                 json.dump(self.cookies, open(COOKIES_FILE, "w"))
 
+        self.check_login()
+
         self.book_id = args.bookid
         self.api_url = self.API_TEMPLATE.format(self.book_id)
 
@@ -511,6 +514,19 @@ class SafariBooks:
         response = self.requests_provider(self.jwt["redirect_uri"])
         if response == 0:
             self.display.exit("Login: unable to reach Safari Books Online. Try again...")
+
+
+    def check_login(self):
+        response = self.requests_provider(PROFILE_URL, perfom_redirect=False)
+
+        if response == 0:
+            self.display.exit("Login: unable to reach Safari Books Online. Try again...")
+
+        if response.status_code != 200:
+            self.display.exit("Authentication issue: unable to access profile page.")
+
+        self.display.info("Successfully authenticated.", state=True)
+
 
     def get_book_info(self):
         response = self.requests_provider(self.api_url)


### PR DESCRIPTION
- orm-rt cookie has floating point max-age (which it shouldn't https://tools.ietf.org/html/rfc6265#section-5.2.2)
- requests library fails to include it in the cookie jar (parsing the string as an int fails and the cookie is discarded: https://github.com/python/cpython/blob/20a4f6cde65549fd0252eb8c879963e0e8b40390/Lib/http/cookiejar.py#L1448)
- in-addition, the 'redirect-uri' was not the same as that used in the browser login flow which uses the 'next' parameter.
- one more change is that there is now a check after the login (or cookie load), to ensure that the profile page is accessible. This helps by failing fast if there is an authentication issue. Previously, the script would continue to process the book but just download truncated chapters. The issues people have raised about truncated chapters seem to all be caused by authentication issues.

Fixes: 
- https://github.com/lorenzodifuccia/safaribooks/issues/146
- https://github.com/lorenzodifuccia/safaribooks/issues/150
