### PR TITLE
Add a filter for image type, avoiding wrong image link.

### DIFF
--- a/safaribooks.py
+++ b/safaribooks.py
@@ -601,8 +601,9 @@ class SafariBooks:
                         link[-3:] in ["jpg", "peg", "png", "gif"]:
                     link = urljoin(self.base_url, link)
                     if link not in self.images:
-                        self.images.append(link)
-                        self.display.log("Crawler: found a new image at %s" % link)
+                        if (".jpg" or ".gif" or ".png" or ".jpeg" or ".svg") in link:
+                            self.images.append(link)
+                            self.display.log("Crawler: found a new image at %s" % link)
 
                     image = link.split("/")[-1]
                     return "Images/" + image


### PR DESCRIPTION
Some images in safari books was a link to a special page like: https://learning.oreilly.com/library/view/bpf-performance-tools/9780136588870/ch04_images.xhtml#p125pro03a.
We should filter this links.