### PR TITLE
#212 / #214: issues Images are not being downloaded properly

### DIFF
--- a/safaribooks.py
+++ b/safaribooks.py
@@ -614,7 +614,7 @@ class SafariBooks:
             if not self.url_is_absolute(link):
                 if "cover" in link or "images" in link or "graphics" in link or \
                         link[-3:] in ["jpg", "peg", "png", "gif"]:
-                    link = urljoin(self.base_url, link)
+                    link = urljoin(self.base_url + self.book_id + "/", link)
                     if link not in self.images:
                         self.images.append(link)
                         self.display.log("Crawler: found a new image at %s" % link)


### PR DESCRIPTION
The URL-Crawler attempts to download images from the wrong location. In specific the book-id is missing.


see #212 / #214, or https://github.com/lorenzodifuccia/safaribooks/issues/212#issuecomment-623030088 for more information.