### PR TITLE
Issue #237: unhandled exception for missing "rights" key

### DIFF
--- a/safaribooks.py
+++ b/safaribooks.py
@@ -171,9 +171,9 @@ class Display:
     def book_info(self, info):
         description = self.parse_description(info["description"]).replace("\n", " ")
         for t in [
-            ("Title", info.get("title", "")), ("Authors", ", ".join(aut["name"] for aut in info.get("authors", ""))),
+            ("Title", info.get("title", "")), ("Authors", ", ".join(aut.get("name", "") for aut in info.get("authors", []))),
             ("Identifier", info.get("identifier", "")), ("ISBN", info.get("isbn", "")),
-            ("Publishers", ", ".join(pub["name"] for pub in info.get("publishers", ""))),
+            ("Publishers", ", ".join(pub.get("name", "") for pub in info.get("publishers", []))),
             ("Rights", info.get("rights", "")),
             ("Description", description[:500] + "..." if len(description) >= 500 else description),
             ("Release Date", info.get("issued", "")),
@@ -951,8 +951,8 @@ class SafariBooks:
             escape(aut["name"])
         ) for aut in self.book_info["authors"])
 
-        subjects = "\n".join("<dc:subject>{0}</dc:subject>".format(escape(sub["name"]))
-                             for sub in self.book_info["subjects"])
+        subjects = "\n".join("<dc:subject>{0}</dc:subject>".format(escape(sub.get("name", "")))
+                             for sub in self.book_info.get("subjects", []))
 
         return self.CONTENT_OPF.format(
             (self.book_info.get("isbn",  self.book_id)),
@@ -960,7 +960,7 @@ class SafariBooks:
             authors,
             escape(self.book_info.get("description", "")),
             subjects,
-            ", ".join(escape(pub["name"]) for pub in self.book_info.get("publishers", "")),
+            ", ".join(escape(pub.get("name", "")) for pub in self.book_info.get("publishers", [])),
             escape(self.book_info.get("rights", "")),
             self.book_info.get("issued", ""),
             self.cover,

--- a/safaribooks.py
+++ b/safaribooks.py
@@ -174,7 +174,7 @@ class Display:
             ("Title", info["title"]), ("Authors", ", ".join(aut["name"] for aut in info["authors"])),
             ("Identifier", info["identifier"]), ("ISBN", info["isbn"]),
             ("Publishers", ", ".join(pub["name"] for pub in info["publishers"])),
-            ("Rights", info["rights"]),
+            ("Rights", info.get("rights", "")),
             ("Description", description[:500] + "..." if len(description) >= 500 else description),
             ("Release Date", info["issued"]),
             ("URL", info["web_url"])
@@ -961,7 +961,7 @@ class SafariBooks:
             escape(self.book_info["description"]),
             subjects,
             ", ".join(escape(pub["name"]) for pub in self.book_info["publishers"]),
-            escape(self.book_info["rights"]) if self.book_info["rights"] else "",
+            escape(self.book_info.get("rights", "")),
             self.book_info["issued"],
             self.cover,
             "\n".join(manifest),

--- a/safaribooks.py
+++ b/safaribooks.py
@@ -171,13 +171,13 @@ class Display:
     def book_info(self, info):
         description = self.parse_description(info["description"]).replace("\n", " ")
         for t in [
-            ("Title", info["title"]), ("Authors", ", ".join(aut["name"] for aut in info["authors"])),
-            ("Identifier", info["identifier"]), ("ISBN", info["isbn"]),
-            ("Publishers", ", ".join(pub["name"] for pub in info["publishers"])),
+            ("Title", info.get("title", "")), ("Authors", ", ".join(aut["name"] for aut in info.get("authors", ""))),
+            ("Identifier", info.get("identifier", "")), ("ISBN", info.get("isbn", "")),
+            ("Publishers", ", ".join(pub["name"] for pub in info.get("publishers", ""))),
             ("Rights", info.get("rights", "")),
             ("Description", description[:500] + "..." if len(description) >= 500 else description),
-            ("Release Date", info["issued"]),
-            ("URL", info["web_url"])
+            ("Release Date", info.get("issued", "")),
+            ("URL", info.get("web_url", ""))
         ]:
             self.info("{0}{1}{2}: {3}".format(self.SH_YELLOW, t[0], self.SH_DEFAULT, t[1]), True)
 
@@ -955,14 +955,14 @@ class SafariBooks:
                              for sub in self.book_info["subjects"])
 
         return self.CONTENT_OPF.format(
-            (self.book_info["isbn"] if self.book_info["isbn"] else self.book_id),
+            (self.book_info.get("isbn",  self.book_id)),
             escape(self.book_title),
             authors,
-            escape(self.book_info["description"]),
+            escape(self.book_info.get("description", "")),
             subjects,
-            ", ".join(escape(pub["name"]) for pub in self.book_info["publishers"]),
+            ", ".join(escape(pub["name"]) for pub in self.book_info.get("publishers", "")),
             escape(self.book_info.get("rights", "")),
-            self.book_info["issued"],
+            self.book_info.get("issued", ""),
             self.cover,
             "\n".join(manifest),
             "\n".join(spine),


### PR DESCRIPTION
Reported issue #237 is caused by unhandled exception thrown for missing key "rights" in the `info` and `book_info` dictionaries when fetching book info.

This PR addresses above issue by replacing "rights" key lookup to using built-in `get` method with default value if the key is missing in the dictionary.

Similar replacements applied to other keys as well to prevent similar missing key exception.