### PR TITLE
Parsing cookies from an extension, instead of capturing them from the browser's console

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,6 @@ __pycache__/
 
 Books/
 
-cookies.json
+*.json
 *.log
 *.txt

--- a/detailed_cookies.py
+++ b/detailed_cookies.py
@@ -1,0 +1,24 @@
+import json
+import safaribooks
+
+
+def parse_cookies_file(file_path):
+    with open(file_path) as f:
+        data = json.load(f)
+        convert_cookies(data)
+
+
+def convert_cookies(cookies):
+    converted_cookies = {}
+    for c in cookies:
+        name = c.get('name')
+        value = c.get('value')
+        converted_cookies[name] = value
+    json.dump(converted_cookies, open(safaribooks.COOKIES_FILE, 'w'))
+
+
+if __name__ == "__main__":
+    import sys
+    if len(sys.argv) < 2:
+        print(f'Usage: {sys.argv[0]} <cookies_file.json>')
+    parse_cookies_file(sys.argv[1])


### PR DESCRIPTION
This is, hopefully, a simpler way to parse the cookies when trying to use SSO. I'm getting them as a JSON, using an extension like [this one](http://www.editthiscookie.com/start/). Then, using the `detailed_cookies.py` script, they can be stored into the default cookie jar file.