### PR TITLE
Fixed OSError: [Errno 22] Invalid argument error for book ID

### DIFF
--- a/safaribooks.py
+++ b/safaribooks.py
@@ -1109,6 +1109,16 @@ if __name__ == "__main__":
         if args_parsed.no_cookies:
             arguments.error("invalid option: `--no-cookies` is valid only if you use the `--cred` option")
 
+    if len(args_parsed.bookid) > 0:
+        bookID = args_parsed.bookid.split("/")[-1]          # Only get book ID from URL
+        if str.isdecimal(bookID):
+            args_parsed.bookid = bookID
+        else:
+            arguments.error("Invalid book ID")
+    else:
+        arguments.error("Book ID must not be empty")
+
+
     SafariBooks(args_parsed)
     # Hint: do you want to download more then one book once, initialized more than one instance of `SafariBooks`...
     sys.exit(0)


### PR DESCRIPTION
Fixes the error:

```text
Traceback (most recent call last):
  File "C:\1-repos\safaribooks\safaribooks.py", line 1112, in <module>
    SafariBooks(args_parsed)
  File "C:\1-repos\safaribooks\safaribooks.py", line 314, in __init__
    self.display = Display("info_%s.log" % escape(args.bookid))
  File "C:\1-repos\safaribooks\safaribooks.py", line 57, in __init__
    logs_handler = logging.FileHandler(filename=self.log_file)
  File "C:\Program Files\Python39\lib\logging\__init__.py", line 1142, in __init__
    StreamHandler.__init__(self, self._open())
  File "C:\Program Files\Python39\lib\logging\__init__.py", line 1171, in _open
    return open(self.baseFilename, self.mode, encoding=self.encoding,
OSError: [Errno 22] Invalid argument: 'C:\\1-repos\\safaribooks\\info_https:\\www.safaribooksonline.com\library\view\test-driven-development-with\9781491958698\\.log'
```
