### PR TITLE
Use python3 venv for installation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ $ git clone https://github.com/lorenzodifuccia/safaribooks.git
 Cloning into 'safaribooks'...
 
 $ cd safaribooks/
+$ python3 -m venv .venv && source .venv/bin/activate
 $ pip3 install -r requirements.txt
 
 OR


### PR DESCRIPTION
Suggest to use python3 venv for installation. This allows users to have non-conflicting dependencies in their base python installation.

**Note:** I am using `.venv` directory, as that is already excluded in the `.gitignore` file.