### PR TITLE
sso_cookies.py: Parse according to RFC 6265

### DIFF
--- a/sso_cookies.py
+++ b/sso_cookies.py
@@ -15,8 +15,7 @@ import safaribooks
 
 def transform(cookies_string):
     cookies = {}
-    for cookie in cookies_string.split(";"):
-        cookie = cookie.strip()
+    for cookie in cookies_string.split("; "):
         key, value = cookie.split("=", 1)
         cookies[key] = value
 


### PR DESCRIPTION
Individual cookies in the `Cookie` header, according to [Section 5.4 of RFC 6265][1],
are separated by the "semicolon-space" (`; `) combination. This becomes relevant
when there is a cookie whose value contains a semicolon. I have just encountered one
on O'Reilly Learning, namely `OptanonConsent` ending in `&geolocation=US;CA`,
which was breaking the script.

[1]: https://www.rfc-editor.org/rfc/rfc6265#section-5.4