### PR TITLE
Remove 'position:absolute' from cover style

### DIFF
--- a/safaribooks.py
+++ b/safaribooks.py
@@ -726,7 +726,7 @@ class SafariBooks:
                 is_cover = self.get_cover(book_content)
                 if is_cover is not None:
                     page_css = "<style>" \
-                               "body{display:table;position:absolute;margin:0!important;height:100%;width:100%;}" \
+                               "body{display:table;margin:0!important;height:100%;width:100%;}" \
                                "#Cover{display:table-cell;vertical-align:middle;text-align:center;}" \
                                "img{height:90vh;margin-left:auto;margin-right:auto;}" \
                                "</style>"


### PR DESCRIPTION
This fixes the cover page in the Apple Books app. The cover page was shifted to the right so that half the page was off the screen. This happens when the book is displayed in 2-page mode.