### PR TITLE
Make cover art show in Apple Books library

### DIFF
--- a/safaribooks.py
+++ b/safaribooks.py
@@ -964,6 +964,8 @@ class SafariBooks:
         subjects = "\n".join("<dc:subject>{0}</dc:subject>".format(escape(sub.get("name", "n/d")))
                              for sub in self.book_info.get("subjects", []))
 
+        cover_id = re.search("\/(\w+)\.", self.cover).group(1)
+
         return self.CONTENT_OPF.format(
             (self.book_info.get("isbn",  self.book_id)),
             escape(self.book_title),
@@ -973,7 +975,7 @@ class SafariBooks:
             ", ".join(escape(pub.get("name", "")) for pub in self.book_info.get("publishers", [])),
             escape(self.book_info.get("rights", "")),
             self.book_info.get("issued", ""),
-            self.cover,
+            'img_{cover_id}',
             "\n".join(manifest),
             "\n".join(spine),
             self.book_chapters[0]["filename"].replace(".html", ".xhtml")


### PR DESCRIPTION
The <meta> tag for the cover needs to point to the <item> tag for the cover image instead of pointing directly to the image file.